### PR TITLE
Added Python support + other languages that doesn't suport multilineal comments

### DIFF
--- a/lib/quick-comment.js
+++ b/lib/quick-comment.js
@@ -58,6 +58,9 @@ export default {
           openComment = "<!--"
           closeComment = "-->"
           break;
+        case "Python":
+          openComment = "'''"
+          closeComment = "'''"
         default:
           openComment = "/*"
           closeComment = "*/"

--- a/lib/quick-comment.js
+++ b/lib/quick-comment.js
@@ -48,9 +48,10 @@ export default {
     let editor                    // Just for quicker writing
     let openComment               // Open comment (/*)
     let closeComment              // Close Comment (*/)
-    var isDisabledMultiline = 0   // Var to detect if doesn't support multiline comments (like Python)
+    var isDisabledMultiline = false   // Var to detect if doesn't support multiline comments (like Python)
     if (editor = atom.workspace.getActiveTextEditor()) {
       switch (editor.getGrammar().name) {
+        case "XML":
         case "HTML":
           openComment = "<!--"
           closeComment = "-->"
@@ -59,9 +60,42 @@ export default {
           openComment = "<!--"
           closeComment = "-->"
           break;
-        case "Python":
-          var isDisabledMultiline = 1; //add this if the lang doesn't support multiline
-          openComment = "#"
+        case "Lua":
+          openComment = "--[["
+          closeComment = "--]]"
+          break;
+        case "MATLAB":
+          openComment = "%{ "
+          closeComment = "%}"
+          break;
+        case "SQL": case "SQL (Rails)": case "SQL (Mustache)": case "MySQL": case "SQLite": case "Transact-SQL": case "ADA":
+          var isDisabledMultiline = true;
+          openComment = "-- "
+          break;
+        case "Perl 6":
+        case "Raku":
+          openComment = "#`{{"
+          closeComment = "}}"
+        case "Powershell":
+          openComment = "<# "
+          closeComment = "#>"
+        case "Python" :
+        case "Ruby" :
+        case "R":
+          var isDisabledMultiline = true; //add this if the lang doesn't support multiline
+          openComment = "# "
+          break;
+        case "APL":
+          var isDisabledMultiline = true;
+          openComment = "⍝ "
+          break;
+        case "AppleScript":
+          openComment = "(*"
+          closeComment = "*)"
+          break;
+        case "VB.NET":
+          isDisabledMultiline = true
+          openComment = "' "
           break;
         default:
           openComment = "/*"

--- a/lib/quick-comment.js
+++ b/lib/quick-comment.js
@@ -89,7 +89,7 @@ export default {
           var isDisabledMultiline = true;
           openComment = "⍝ "
           break;
-        case "Fortran - Fixed Form": case "Fortran - Free Form": case "Fortran - Modern": case "source.fortran.preprocessor": case "Fortran - Punchcard":
+        case "Fortran - Fixed Form": case "Fortran - Free Form": case "Fortran - Modern": case "source.fortran.preprocessor": case "Fortran - Punchcard": case "FORTRAN":
           var isDisabledMultiline = true;
           openComment = "!"
           break;

--- a/lib/quick-comment.js
+++ b/lib/quick-comment.js
@@ -45,9 +45,10 @@ export default {
 
   //Package functions below
   toggleComment() {
-    let editor
-    let openComment
-    let closeComment
+    let editor                    // Just for quicker writing
+    let openComment               // Open comment (/*)
+    let closeComment              // Close Comment (*/)
+    var isDisabledMultiline = 0   // Var to detect if doesn't support multiline comments (like Python)
     if (editor = atom.workspace.getActiveTextEditor()) {
       switch (editor.getGrammar().name) {
         case "HTML":
@@ -59,27 +60,45 @@ export default {
           closeComment = "-->"
           break;
         case "Python":
-          openComment = "'''"
-          closeComment = "'''"
+          var isDisabledMultiline = 1; //add this if the lang doesn't support multiline
+          openComment = "#"
+          break;
         default:
           openComment = "/*"
           closeComment = "*/"
       }
 
-      let selection = editor.getSelectedText()
-      if (selection == "") {
+      let selection = editor.getSelectedText();
+      if (selection == "") { //if the text selected is empty
         editor.moveToEndOfLine()
         editor.selectToFirstCharacterOfLine()
-        selection = editor.getSelectedText()
+        selection = editor.getSelectedText() //selects all texts in the line
       }
-      if (selection.indexOf(openComment) > -1 && selection.indexOf(closeComment) > -1) {
+      if (selection.indexOf(openComment) > -1 && selection.indexOf(closeComment) > -1) { //Detects if it's already been commented
         let uncommented = selection.replace(openComment, "").replace(closeComment, "")
         editor.insertText(uncommented)
+      } else if (isDisabledMultiline) { //Some langs like Python doesn't support multiline comments
+        let splitText = selection.split("\n");
+        if (selection.indexOf(openComment) > -1) { //Same as before but for "Python like"
+          let uncommented = [];
+          for (var i = 0; i < splitText.length; i++) {
+            uncommented[i] = splitText[i].replace(openComment, "")
+          }
+          let joinedText = uncommented.join("\n")
+          editor.insertText(joinedText)
+        } else {
+          let commented = [];
+          for (var i = 0; i < splitText.length; i++) { //This loop adds the comment symbol before each line
+            commented[i] = openComment.concat(splitText[i]);
+          }
+          let joinedText = commented.join("\n")
+          editor.insertText(joinedText)
+        }
       } else {
         let commented = openComment.concat(selection, closeComment)
         editor.insertText(commented)
       }
-    }
+    };
   },
 
   addBrackets() {

--- a/lib/quick-comment.js
+++ b/lib/quick-comment.js
@@ -89,6 +89,10 @@ export default {
           var isDisabledMultiline = true;
           openComment = "⍝ "
           break;
+        case "Fortran - Fixed Form": case "Fortran - Free Form": case "Fortran - Modern": case "source.fortran.preprocessor": case "Fortran - Punchcard":
+          var isDisabledMultiline = true;
+          openComment = "!"
+          break;
         case "AppleScript":
           openComment = "(*"
           closeComment = "*)"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "quick-comment",
   "main": "./lib/quick-comment",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "A simple shortcut to comment your code or text",
   "keywords": [
     "fast",


### PR DESCRIPTION
In JavaScript you can multi-line comment using `/*` and `*/` 

In Python, however, you can only comment each line one-by-one using the `#`symbol.

Now, the code does this pretty well. I've added comments explaining how it works.

Also, we can jump to version 0.2.0 because it add this new feature that can lead to add more and more languages that supports or doesn't support multi-lineal commentaries.